### PR TITLE
Update dependencies versions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       - 6379
 
   mongodb:
-    image: mongo:3.6.14
+    image: mongo:3.6.20
     restart: always
     expose:
       - 27017
@@ -49,7 +49,7 @@ services:
 
       # - ./application/document_stats.py:/home/flask/app/application/document_stats.py
       - ./application/templates/index.html:/home/flask/app/application/templates/index.html
-    command: /usr/local/bin/gunicorn -w 1 -b :8001 application:app
+    command: /usr/local/bin/gunicorn -w 3 -b :8001 application:app
     links:
       - redis
     depends_on:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ rq-dashboard==0.5.1
 rq==1.1.0
 supervisor==4.0.3
 gunicorn==19.9.0
-Click
-flask_cors
-fitz
-PyMuPDF
+click==7.1.2
+flask_cors==3.0.9
+fitz==0.0.1.dev2
+PyMuPDF==1.18.1


### PR DESCRIPTION
Some dependencies doesn't specify the version. If program keeps on using the latest version, the program may be broken due the backward compatibility has been done not well.